### PR TITLE
fix: fix function call and remove unused import statement

### DIFF
--- a/httpapi.go
+++ b/httpapi.go
@@ -14,13 +14,13 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
 )
 
-//IncomingMsg :
+// IncomingMsg :
 type IncomingMsg struct {
 	User        string `json:"User"`
 	Repo        string `json:"Repo"`
@@ -31,7 +31,7 @@ type IncomingMsg struct {
 func bookmarkPost(w http.ResponseWriter, req *http.Request) {
 	var in IncomingMsg
 
-	body, err := ioutil.ReadAll(req.Body)
+	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		log.Println("Data read error:", err)
 		return


### PR DESCRIPTION
- Fix a function call to `ioutil.ReadAll` by changing it to `io.ReadAll`
- Remove unused import statement for `io/ioutil`