### PR TITLE
ci: update workflow trigger and release command

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -2,7 +2,8 @@ name: goreleaser
 
 on:
   push:
-    branches: [ master ]
+    tags:
+      - '*'
 
 permissions:
   contents: write
@@ -26,6 +27,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
-          args: release --clean
+          args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Modify the trigger of the workflow to include tags
- Change the `args` parameter to `release --rm-dist`